### PR TITLE
Finalize CHANGELOG for 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **WMI dependency service enforcement** — `Confirm-CWAADependencyService` ensures `winmgmt` (WMI) is set to Automatic startup and Running before install, repair, and service start. Configurable via `$Script:CWAADependencyServiceNames`; respects `-WhatIf`. Event IDs 2030–2039.
-
 ### Changed
 
 ### Fixed
+
+## [2.1.0] - 2026-06-17
+
+### Added
+
+- **WMI dependency service enforcement** — `Confirm-CWAADependencyService` ensures `winmgmt` (WMI) is set to Automatic startup and Running before install, repair, and service start. Configurable via `$Script:CWAADependencyServiceNames`; respects `-WhatIf`. Event IDs 2030–2039.
 
 ## [2.0.0] - 2026-02-03
 


### PR DESCRIPTION
Moves the WMI dependency service enforcement entry from `[Unreleased]` into a dated `## [2.1.0] - 2026-06-17` section so the stable release job extracts proper GitHub Release notes. Prep for the develop → main promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)