### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/Scripts/Invoke-QuickTest.ps1
+++ b/Scripts/Invoke-QuickTest.ps1
@@ -209,7 +209,7 @@ if ($IncludeAnalyzer) {
 # --- Build output ---
 
 $failedTests = @()
-if ($results.FailedCount -gt 0) {
+if (($results.FailedCount + $results.FailedBlocksCount + $results.FailedContainersCount) -gt 0) {
     $failedTests = @($results.Failed | ForEach-Object {
         $relativePath = if ($_.ScriptBlock.File) {
             $_.ScriptBlock.File -replace [regex]::Escape($ProjectRoot + [IO.Path]::DirectorySeparatorChar), ''
@@ -226,10 +226,10 @@ if ($results.FailedCount -gt 0) {
 
 $totalDuration = '{0:N2}s' -f $results.Duration.TotalSeconds
 
-$success = ($results.FailedCount -eq 0) -and ($analyzerErrors.Count -eq 0)
+$success = (($results.FailedCount + $results.FailedBlocksCount + $results.FailedContainersCount) -eq 0) -and ($analyzerErrors.Count -eq 0)
 $summaryParts = @()
 if ($results.PassedCount -gt 0) { $summaryParts += "$($results.PassedCount) passed" }
-if ($results.FailedCount -gt 0) { $summaryParts += "$($results.FailedCount) failed" }
+if (($results.FailedCount + $results.FailedBlocksCount + $results.FailedContainersCount) -gt 0) { $summaryParts += "$($results.FailedCount) failed" }
 if ($results.SkippedCount -gt 0) { $summaryParts += "$($results.SkippedCount) skipped" }
 $summaryText = if ($success) { "PASSED ($($summaryParts -join ', '))" } else { "FAILED ($($summaryParts -join ', '))" }
 
@@ -259,7 +259,7 @@ else {
     Write-Host "=== QUICK TEST: $label ===" -ForegroundColor Cyan
 
     # Failed test details
-    if ($results.FailedCount -gt 0) {
+    if (($results.FailedCount + $results.FailedBlocksCount + $results.FailedContainersCount) -gt 0) {
         Write-Host ""
         Write-Host "FAILED TESTS:" -ForegroundColor Red
         foreach ($ft in $failedTests) {


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This change includes all three counts in the gate. Display/log messages are left unchanged.
